### PR TITLE
Add a feature to filter out sensitive data from logs

### DIFF
--- a/excon_honeypot.gemspec
+++ b/excon_honeypot.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'excon_honeypot'
-  spec.version       = '0.1.8'
+  spec.version       = '0.1.9'
   spec.authors       = ['Andrzej Trzaska']
   spec.email         = ['atrzaska2@gmail.com']
 


### PR DESCRIPTION
Adds a simple mechanism to filter out sensitive data from logs

Example:

```
Excon: Request with ID: 58f76e2a-52cf-45bf-a954-643f7edb7bb6 PUT https://api.hubapi.com/properties/v1/contacts/properties/named/phone_number?hapikey=<filtered> with body: "{"type":"string","fieldType":"text","groupName":"honeypot","displayOrder":-1,"hasUniqueValue":false,"hidden":false,"formField":false,"name":"phone_number","label":"Phone number (generated)"}" returned 200 and took 395ms
```